### PR TITLE
Add ilamb dignostic job

### DIFF
--- a/jobs/cmor.py
+++ b/jobs/cmor.py
@@ -61,7 +61,7 @@ class Cmor(Job):
 
     def postvalidate(self, config, *args, **kwargs):
         """
-        Validate that the CMOR job completed successfuly
+        Validate that the CMOR job completed successfully
 
         Parameters
         ----------

--- a/jobs/ilamb.py
+++ b/jobs/ilamb.py
@@ -1,0 +1,242 @@
+"""
+A wrapper class around ILAMB
+"""
+import os
+import glob
+import logging
+
+from jobs.diag import Diag
+from lib.util import render, get_cmor_output_files, format_debug
+from lib.jobstatus import JobStatus
+
+
+class ILAMB(Diag):
+    def __init__(self, *args, **kwargs):
+        """
+        Parameters
+        ----------
+            config (dict): the global configuration object
+            custom_args (dict): a dictionary of user supplied arguments
+                to pass to the resource manager
+        """
+        super(ILAMB, self).__init__(*args, **kwargs)
+        self._job_type = 'ilamb'
+        self._requires = ''
+        self._host_url = ''
+        self.case_start_year = kwargs['config']['simulations']['start_year']
+        self._data_required = ['atm', 'lnd']
+
+        if kwargs['config']['global']['host']:
+            self._host_path = os.path.join(
+                kwargs['config']['img_hosting']['host_directory'],
+                self.short_name,
+                'ilamb',
+                '{start:04d}_{end:04d}_vs_{comp}'.format(
+                    start=self.start_year,
+                    end=self.end_year,
+                    comp=self._short_comp_name))
+        else:
+            self._host_path = 'html'
+
+        custom_args = kwargs['config']['diags'][self.job_type].get(
+            'custom_args')
+        if custom_args:
+            self.set_custom_args(custom_args)
+
+        # setup the output directory, creating it if it doesnt already exist
+        custom_output_path = kwargs['config']['diags'][self.job_type].get(
+            'custom_output_path')
+        if custom_output_path:
+            self._replace_dict['COMPARISON'] = self._short_comp_name
+            self._output_path = self.setup_output_directory(custom_output_path)
+        else:
+            self._output_path = os.path.join(
+                kwargs['config']['global']['project_path'],
+                'output',
+                'diags',
+                self.short_name,
+                self.job_type,
+                '{start:04d}_{end:04d}_vs_{comp}'.format(
+                    start=self.start_year,
+                    end=self.end_year,
+                    comp=self._short_comp_name))
+        if not os.path.exists(self._output_path):
+            os.makedirs(self._output_path)
+
+        # need to know the cmor output directory as well
+        custom_args = kwargs['config']['post-processing'][self.job_type].get(
+            'custom_args')
+        if custom_args:
+            self.set_custom_args(custom_args)
+
+        # setup the output directory, creating it if it doesnt already exist
+        custom_cmor_path = kwargs['config']['post-processing']['cmor'].get(
+            'custom_output_path')
+        if custom_cmor_path:
+            self._cmor_path = self.setup_output_directory(custom_cmor_path)
+        else:
+            self._cmor_path = os.path.join(
+                kwargs['config']['global']['project_path'],
+                'output', 'pp', 'cmor', self.short_name, 'cmor')
+
+    def _dep_filter(self, job):
+        """
+        find the CMOR job we're waiting for, assuming there's only
+        one CMOR job in this case with the same start and end years
+        """
+        if job.job_type != self._requires:
+            return False
+        if job.start_year != self.start_year:
+            return False
+        if job.end_year != self.end_year:
+            return False
+        return True
+
+    def setup_dependencies(self, jobs, *args, **kwargs):
+        """
+        Adds CMOR jobs from this or the comparison case to the list of
+        dependent jobs
+
+        Parameters
+        ----------
+            jobs (list): a list of the rest of the run managers jobs
+            optional: comparison_jobs (list): if this job is being compared to
+                another case, the cmorized output for that other case has to
+                be done already too
+        """
+        if self.comparison != 'obs':
+            other_jobs = kwargs['comparison_jobs']
+            try:
+                self_cmor, = filter(lambda job: self._dep_filter(job),
+                                    other_jobs)
+            except ValueError:
+                msg = 'Unable to find CMOR for {}, is this case set to ' \
+                      'generate CMORized output?'.format(self.msg_prefix())
+                raise Exception(msg)
+        else:
+            try:
+                self_cmor, = filter(lambda job: self._dep_filter(job), jobs)
+            except ValueError:
+                msg = 'Unable to find CMOR for {}, is this case set to ' \
+                      'generate CMORized output?'.format(self.msg_prefix())
+                raise Exception(msg)
+
+    def execute(self, config, event_list, slurm_args=None, dryrun=False):
+        """
+        Generates and submits a run script for ILAMB
+
+        Parameters
+        ----------
+            config (dict): the globus processflow config object
+            dryrun (bool): a flag to denote that all the data should be set,
+                and the scripts generated, but not actually submitted
+        """
+        self._dryrun = dryrun
+        ilamb_config = config['diags']['ilamb']
+
+        # setup template
+        template_out = os.path.join(
+            config['global']['run_scripts_path'],
+            '{job}_{start:04d}_{end:04d}_{case}_vs_{comp}.cfg'.format(
+                job=self._job_type,
+                start=self.start_year,
+                end=self.end_year,
+                case=self.short_name,
+                comp=self._short_comp_name))
+        template_input_path = os.path.join(
+            config['global']['resource_path'],
+            'ilamb_vs_obs.cfg')
+
+        # remove previous run script if it exists
+        if os.path.exists(template_out):
+            os.remove(template_out)
+        render(
+            variables={},
+            input_path=template_input_path,
+            output_path=template_out)
+
+        models_dir = os.path.join(self._output_path, 'MODELS')
+        if not os.path.exists(models_dir):
+            os.mkdir(models_dir)
+        if not os.path.exists(os.path.join(models_dir, self.short_name)):
+            os.mkdir(os.path.join(models_dir, self.short_name))
+        cmor_files = get_cmor_output_files(os.path.abspath(self._cmor_path),
+                                           self.start_year,
+                                           self.end_year)
+        for file_ in cmor_files:
+            destination = os.path.join(models_dir, self.short_name,
+                                       os.path.basename(file_))
+            if os.path.lexists(destination):
+                continue
+            try:
+                os.symlink(file_, destination)
+            except Exception as e:
+                msg = format_debug(e)
+                logging.error(msg)
+
+        cmd = ['ilamb-run',
+               '--config', template_out,
+               '--model_root', models_dir,
+               '--models', self.short_name,
+               '--build_dir', self._host_path]
+        if ilamb_config.get('confrontation'):
+            cmd.extend(['--confrontation', ilamb_config['confrontation']])
+        if ilamb_config.get('shift_from') and ilamb_config.get('shift_to'):
+            cmd.extend(['--model_year',
+                        '{} {}'.format(ilamb_config['shift_from'],
+                                       ilamb_config['shift_to'])
+                        ])
+        if ilamb_config.get('regions'):
+            cmd.extend(['--regions', ilamb_config['regions']])
+        if ilamb_config.get('region_definition_files'):
+            cmd.extend(['--define_regions',
+                        ilamb_config['region_definition_files']])
+        if ilamb_config.get('clean') in [1, '1', 'true', 'True']:
+            cmd.append('--clean')
+        if ilamb_config.get('disable_logging') in [1, '1', 'true', 'True']:
+            cmd.append('--disable_logging')
+
+        self._has_been_executed = True
+        return self._submit_cmd_to_manager(config, cmd, event_list)
+
+    def postvalidate(self, config, *args, **kwargs):
+        """
+        Validates that the diagnostic produced its expected output
+
+        Parameters
+        ----------
+            config (dict): the global cofiguration object
+        Returns
+        -------
+            True if all output exists as expected
+            False otherwise
+        """
+        # if the job ran through slurm can came back complete, just return True
+        if self.status == JobStatus.COMPLETED:
+            return True
+        elif self.status == JobStatus.FAILED:
+            return False
+        # otherwise, maybe this job hasnt been run yet in this instance, but the
+        # output might be there
+        else:
+            logs = glob.glob(os.path.join(self._host_path, 'ILAMB*.log'))
+            if logs:
+                return True
+            else:
+                return False
+
+    def handle_completion(self, filemanager, event_list, config,
+                          *args, **kwargs):
+        """
+        Setup for webhosting after a successful run
+
+        ILAMB handles moving the files to the correct location, so no extra
+        handling is required
+
+        Parameters
+        ----------
+            filemanager ():
+            event_list (EventList): event list to push user notifications into
+            config (dict): the global config object
+        """
+        pass

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -263,7 +263,7 @@ class Job(object):
         to the resource manager controller
 
         Parameters:
-            cmd (str): the command to submit
+            cmd (list): a list of the command and its arguments to submit
             config (dict): the global configuration object
         Returns:
             job_id (int): the job_id from the resource manager

--- a/jobs/job.py
+++ b/jobs/job.py
@@ -155,7 +155,7 @@ class Job(object):
                     datatype=datatype,
                     case=case)
             if not files or len(files) == 0:
-                msg = '{prefix}: filemanager cant find input files for datatype {datatype}'.format(
+                msg = "{prefix}: filemanager can't find input files for datatype {datatype}".format(
                     prefix=self.msg_prefix(),
                     datatype=datatype)
                 logging.error(msg)

--- a/lib/runmanager.py
+++ b/lib/runmanager.py
@@ -24,6 +24,7 @@ from jobs.e3smdiags import E3SMDiags
 from jobs.aprime import Aprime
 from jobs.cmor import Cmor
 from jobs.mpasanalysis import MPASAnalysis
+from jobs.ilamb import ILAMB
 from lib.jobstatus import JobStatus, StatusMap, ReverseMap
 from lib.jobinfo import JobInfo
 
@@ -35,7 +36,8 @@ job_map = {
     'amwg': AMWG,
     'aprime': Aprime,
     'cmor': Cmor,
-    'mpas_analysis': MPASAnalysis
+    'mpas_analysis': MPASAnalysis,
+    'ilamb': ILAMB
 }
 
 

--- a/lib/util.py
+++ b/lib/util.py
@@ -43,6 +43,32 @@ def print_line(line, event_list, ignore_text=False, newline=True):
         sys.stdout.flush()
 
 
+def get_cmor_output_files(input_path, start_year, end_year):
+    """
+    Return a list of CMORize output files from start_year to end_year
+
+    Parameters:
+        input_path (str): the directory to look in
+        start_year (int): the first year of climos to add to the list
+        end_year (int): the last year
+    Returns:
+        cmor_list (list): A list of the cmor files
+    """
+    if not os.path.exists(input_path):
+        return None
+    cmor_list = list()
+
+    pattern = r'_{start:04d}01_{end:04d}12\.nc'.format(
+        start=start_year, end=end_year)
+
+    for root, dirs, files in os.walk(input_path):
+        for file_ in files:
+            if re.search(pattern, file_):
+                cmor_list.append(os.path.join(root, file_))
+
+    return cmor_list
+
+
 def get_climo_output_files(input_path, start_year, end_year):
     """
     Return a list of ncclimo climatologies from start_year to end_year

--- a/lib/util.py
+++ b/lib/util.py
@@ -6,6 +6,7 @@ import os
 import socket
 import jinja2
 import json
+import errno
 
 from shutil import rmtree
 from time import sleep
@@ -58,7 +59,7 @@ def get_cmor_output_files(input_path, start_year, end_year):
         return None
     cmor_list = list()
 
-    pattern = r'_{start:04d}01_{end:04d}12\.nc'.format(
+    pattern = r'_{start:04d}01-{end:04d}12\.nc'.format(
         start=start_year, end=end_year)
 
     for root, dirs, files in os.walk(input_path):
@@ -234,3 +235,19 @@ def create_symlink_dir(src_dir, src_list, dst):
         except Exception as e:
             msg = format_debug(e)
             logging.error(msg)
+
+def mkdir_p(path):
+    """
+    Make parent directories as needed and no error if existing. Works like
+    `mkdir -p`.
+
+    Prameterrs:
+        path (str): the path to directory to make
+    """
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise

--- a/lib/verify_config.py
+++ b/lib/verify_config.py
@@ -377,7 +377,7 @@ def verify_config(config):
         # ------------------------------------------------------------------------
         if config['diags'].get('mpas_analysis'):
             if not config['diags']['mpas_analysis'].get('run_frequency'):
-                msg = 'no run_frequency given for aprime'
+                msg = 'no run_frequency given for MPAS-analysis'
                 messages.append(msg)
             else:
                 if not isinstance(config['diags']['mpas_analysis']['run_frequency'], list):

--- a/lib/verify_config.py
+++ b/lib/verify_config.py
@@ -393,6 +393,23 @@ def verify_config(config):
             if not isinstance(config['diags']['mpas_analysis'].get('generate_plots', ''), list):
                 config['diags']['mpas_analysis']['generate_plots'] = [
                     config['diags']['mpas_analysis'].get('generate_plots', '')]
+        # ------------------------------------------------------------------------
+        # check ILAMB
+        # ------------------------------------------------------------------------
+        if config['diags'].get('ilamb'):
+            from pprint import pprint as pp
+            pp(config['diags']['ilamb'])
+            if not config['diags']['ilamb'].get('run_frequency'):
+                msg = 'no run_frequency given for ILAMB'
+                messages.append(msg)
+            else:
+                if not isinstance(
+                        config['diags']['ilamb']['run_frequency'], list):
+                    config['diags']['ilamb']['run_frequency'] = [
+                        config['diags']['ilamb']['run_frequency']]
+            if not config['diags']['ilamb'].get('ilamb_root'):
+                msg = 'no ilamb_root given for ILAMB'
+                messages.append(msg)
     return messages
 # ------------------------------------------------------------------------
 

--- a/lib/verify_config.py
+++ b/lib/verify_config.py
@@ -397,8 +397,6 @@ def verify_config(config):
         # check ILAMB
         # ------------------------------------------------------------------------
         if config['diags'].get('ilamb'):
-            from pprint import pprint as pp
-            pp(config['diags']['ilamb'])
             if not config['diags']['ilamb'].get('run_frequency'):
                 msg = 'no run_frequency given for ILAMB'
                 messages.append(msg)

--- a/resources/e3sm_user_config_picontrol.json
+++ b/resources/e3sm_user_config_picontrol.json
@@ -1,0 +1,83 @@
+{
+  "_control_vocabulary_file": "CMIP6_CV.json",
+
+  "_AXIS_ENTRY_FILE": "CMIP6_coordinate.json",
+
+  "_FORMULA_VAR_FILE": "CMIP6_formula_terms.json",
+
+  "_cmip6_option": "CMIP6",
+
+  "tracking_prefix": "hdl:21.14100",
+
+  "activity_id": "CMIP",
+
+  "outpath": "CMIP6",
+
+  "experiment_id": "piControl",
+
+  "sub_experiment_id": "none",
+
+  "sub_experiment": "none",
+
+  "source_type": "AOGCM AER",
+
+  "mip_era": "CMIP6",
+
+  "calendar": "noleap",
+
+  "realization_index": "1",
+
+  "initialization_index": "1",
+
+  "physics_index": "1",
+
+  "forcing_index": "1",
+
+  "contact ": "Dave Bader (bader2@llnl.gov)",
+
+  "history": "Output from 20180129.DECKv1b_piControl.ne30_oEC.edison",
+
+  "comment": "",
+
+  "references": "Golaz, J.-C., P. M. Caldwell, L. P. Van Roekel and co-authors, 2019: The DOE E3SM coupled model version 1: Overview and evaluation at standard resolution. JAMES, submitted; http://e3sm.org",
+
+  "grid": "gs1x1",
+
+  "grid_label": "gr",
+
+  "nominal_resolution": "100 km",
+
+  "institution_id": "E3SM-Project",
+
+  "branch_time_in_parent": "0.0D0",
+
+  "branch_time_in_child": "0.0D0",
+
+  "parent_experiment_id": "piControl-spinup",
+
+  "parent_activity_id": "CMIP",
+
+  "parent_mip_era": "CMIP6",
+
+  "parent_source_id": "E3SM-1-0",
+
+  "parent_time_units": "days since 0001-01-01",
+
+  "parent_variant_label": "r1i1p1f1",
+
+  "branch_method": "Spin-up documentation",
+
+  "run_variant": "",
+
+  "source_id": "E3SM-1-0",
+
+  "source": "E3SM 1.0 (2018)",
+
+  "_history_template": "%s ;rewrote data to be consistent with <activity_id> for variable <variable_id> found in table <table_id>.",
+
+  "output_path_template": "<mip_era><activity_id><institution_id><source_id><experiment_id><_member_id><table><variable_id><grid_label><version>",
+
+  "output_file_template": "<variable_id><table><source_id><experiment_id><_member_id><grid_label>",
+
+  "license": "CMIP6 model data produced by E3SM is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License (https://creativecommons.org/licenses/).  Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment.  Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file).  The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
+}

--- a/resources/ilamb_vs_obs.cfg
+++ b/resources/ilamb_vs_obs.cfg
@@ -1,0 +1,221 @@
+# This configure file uses observational data which can be obtained by
+# running the following command after exporting ILAMB_ROOT to the
+# appropriate location.
+#
+#   ilamb-fetch --remote_root http://ilamb.ornl.gov/ILAMB-Data
+#
+
+[h1: Ecosystem and Carbon Cycle]
+bgcolor = "#ECFFE6"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Leaf Area Index]
+variable       = "lai"
+cmap           = "Greens"
+weight         = 3
+mass_weighting = True
+
+[AVHRR]
+source        = "DATA/lai/AVHRR/lai_0.5x0.5.nc"
+weight        = 15
+relationships = "Precipitation/GPCP2"
+
+[MODIS]
+source        = "DATA/lai/MODIS/lai_0.5x0.5.nc"
+weight        = 15
+relationships = "Precipitation/GPCP2"
+skip_iav      = True
+
+###########################################################################
+
+[h1: Hydrology Cycle]
+bgcolor = "#E6F9FF"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Latent Heat]
+variable       = "hfls"
+alternate_vars = "le"
+cmap           = "Oranges"
+weight         = 5
+mass_weighting = True
+
+[Fluxnet]
+source   = "DATA/le/FLUXNET/le.nc"
+weight   = 3
+
+[GBAF]
+source   = "DATA/le/GBAF/le_0.5x0.5.nc"
+land     = True
+weight   = 9
+skip_iav = True
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Sensible Heat]
+variable       = "hfss"
+alternate_vars = "sh"
+weight         = 2
+mass_weighting = True
+
+[Fluxnet]
+source   = "DATA/sh/FLUXNET/sh.nc"
+weight   = 9
+
+[GBAF]
+source   = "DATA/sh/GBAF/sh_0.5x0.5.nc"
+weight   = 15
+skip_iav = True
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Permafrost]
+variable = "tsl"
+
+[NSIDC]
+ctype    = "ConfPermafrost"
+source   = "DATA/permafrost/NSIDC/NSIDC_0.5x0.5.nc"
+y0       = 1970.
+yf       = 2000.
+Teps     = 273.15
+dmax     = 3.5
+
+###########################################################################
+
+[h1: Radiation and Energy Cycle]
+bgcolor = "#FFECE6"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Surface Upward SW Radiation]
+variable = "rsus"
+weight   = 1
+
+[CERES]
+source   = "DATA/rsus/CERES/rsus_0.5x0.5.nc"
+weight   = 15
+
+[GEWEX.SRB]
+source   = "DATA/rsus/GEWEX.SRB/rsus_0.5x0.5.nc"
+weight   = 15
+
+[WRMC.BSRN]
+source   = "DATA/rsus/WRMC.BSRN/rsus.nc"
+weight   = 12
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Surface Upward LW Radiation]
+variable = "rlus"
+weight   = 1
+
+[CERES]
+source   = "DATA/rlus/CERES/rlus_0.5x0.5.nc"
+weight   = 15
+
+[GEWEX.SRB]
+source   = "DATA/rlus/GEWEX.SRB/rlus_0.5x0.5.nc"
+weight   = 15
+
+[WRMC.BSRN]
+source   = "DATA/rlus/WRMC.BSRN/rlus.nc"
+weight   = 12
+
+###########################################################################
+
+[h1: Forcings]
+bgcolor = "#EDEDED"
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Surface Air Temperature]
+variable = "tas"
+weight   = 2
+
+[CRU]
+source   = "DATA/tas/CRU/tas_0.5x0.5.nc"
+weight   = 25
+
+[Fluxnet]
+source   = "DATA/tas/FLUXNET/tas.nc"
+weight   = 9
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Precipitation]
+variable       = "pr"
+cmap           = "Blues"
+weight         = 2
+mass_weighting = True
+
+[CMAP]
+source     = "DATA/pr/CMAP/pr_0.5x0.5.nc"
+land       = True
+weight     = 20
+table_unit = "mm d-1"
+plot_unit  = "mm d-1"
+space_mean = True
+
+[Fluxnet]
+source     = "DATA/pr/FLUXNET/pr.nc"
+land       = True
+weight     = 9
+table_unit = "mm d-1"
+plot_unit  = "mm d-1"
+
+[GPCC]
+source     = "DATA/pr/GPCC/pr_0.5x0.5.nc"
+land       = True
+weight     = 20
+table_unit = "mm d-1"
+plot_unit  = "mm d-1"
+space_mean = True
+
+[GPCP2]
+source     = "DATA/pr/GPCP2/pr_0.5x0.5.nc"
+land       = True
+weight     = 20
+table_unit = "mm d-1"
+plot_unit  = "mm d-1"
+space_mean = True
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Surface Downward SW Radiation]
+variable = "rsds"
+weight   = 2
+
+[CERES]
+source   = "DATA/rsds/CERES/rsds_0.5x0.5.nc"
+weight   = 15
+
+[Fluxnet]
+source   = "DATA/rsds/FLUXNET/rsds.nc"
+weight   = 12
+
+[GEWEX.SRB]
+source   = "DATA/rsds/GEWEX.SRB/rsds_0.5x0.5.nc"
+weight   = 15
+
+[WRMC.BSRN]
+source   = "DATA/rsds/WRMC.BSRN/rsds.nc"
+weight   = 12
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Surface Downward LW Radiation]
+variable = "rlds"
+weight   = 1
+
+[CERES]
+source   = "DATA/rlds/CERES/rlds_0.5x0.5.nc"
+weight   = 15
+
+[GEWEX.SRB]
+source   = "DATA/rlds/GEWEX.SRB/rlds_0.5x0.5.nc"
+weight   = 15
+
+[WRMC.BSRN]
+source   = "DATA/rlds/WRMC.BSRN/rlds.nc"
+weight   = 12

--- a/run.cfg
+++ b/run.cfg
@@ -193,7 +193,7 @@
          shift_to = 2000
          # limit ILAMB to this comma separated list of confrontations
          confrontation = CERES
-         # a comma separated list of regions to analyse
+         # a comma separated list of regions to analyze
          regions = global, usa
          # a comma separated list of txt or nc files defining an analysis region
          region_definition_files = usa.txt

--- a/run.cfg
+++ b/run.cfg
@@ -183,6 +183,24 @@
         run_MOC = True
         ocean_namelist_name = mpaso_in
         seaice_namelist_name = mpassi_in
+    # ILAMB options
+    [[ilamb]]
+         run_frequency = 1
+         # location of the ILAMB obs data
+         ilamb_root = /p/user_pub/e3sm/kennedy52/ilamb_data
+         # shift the time (years) of all models in the analysis
+         shift_from = 1
+         shift_to = 2000
+         # limit ILAMB to this comma separated list of confrontations
+         confrontation = CERES
+         # a comma separated list of regions to analyse
+         regions = global, usa
+         # a comma separated list of txt or nc files defining an analysis region
+         region_definition_files = usa.txt
+         # rerun the analysis even if intermediate files are present
+         clean = False
+         # Disable MPI logger -- use ONLY if you see ILAMB locking up on your system (e.g., geysey at NCAR)
+         disable_logging = False
 
 
 # data type definitions. If all the cases use short term archiving nothing should have to change


### PR DESCRIPTION
This adds [ILAMB](https://www.ilamb.org/) as a diagnostic job.

Currently,  this adds ILAMB analyses for the union of:
* The set of ILAMB analysis (CMOR) variables in the master `ilamb.cfg`
* The set of CMOR output variables available from E3SM

More analyses can be added by creating more CMOR handlers (see: E3SM-Project/e3sm_to_cmip#7)

----
TODO: 

- [ ] Document ILAMB config options
- [ ] more thorough verification of ILAMB config options
- [ ] Update conda build recipe
- [ ] add ILAMB test

@sterlingbaldwin , it's up to you how important these are for getting an initial setup of ILAMB vs issues that should be opened and addressed later. 