### PR TITLE
Remove pinnings of python version for noarch

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,11 +17,11 @@ about:
 
 requirements:
   host:
-    - python {{ python }}
+    - python
     - pip
   
   run:
-    - python {{ python }}
+    - python
     - mpas-analysis >=1.2.5
     - nco >=4.8.1
     - e3sm_diags >=1.7.1


### PR DESCRIPTION
Before this merge, the recipe creates a "noarch" package but one requiring python 3.6

closes #164 